### PR TITLE
Remove unnecessary type checks for function arguments.

### DIFF
--- a/DLL/GDKExtension/GDKX.cpp
+++ b/DLL/GDKExtension/GDKX.cpp
@@ -237,12 +237,6 @@ void F_XboxOneGetUser(RValue& Result, CInstance* selfinst, CInstance* otherinst,
 	Result.kind = VALUE_INT64;
 	Result.v64 = 0;
 
-	if ((argc != 1) || (arg[0].kind != VALUE_REAL))
-	{
-		YYError("xboxone_get_user() - argument should be a user number but it is not.", false);
-		return;
-	}
-
 	int numusers = 0;
 	XUMuser** users = XUM::GetUsers(numusers);
 
@@ -361,13 +355,6 @@ void F_XboxOneShowAccountPicker(RValue& Result, CInstance* selfinst, CInstance* 
 	}
 	else
 	{
-		if ((argc < 2) || (arg[0].kind != VALUE_REAL) || (arg[1].kind != VALUE_REAL))
-		{
-			YYError("xboxone_show_account_picker() - invalid arguments", false);
-			Result.val = -1;
-			return;
-		}
-
 		int optionsval = YYGetInt32(arg, 1);
 		if (optionsval == 1)
 			options = XUserAddOptions::AllowGuests;

--- a/DLL/GDKExtension/YoYo_FunctionsM.cpp
+++ b/DLL/GDKExtension/YoYo_FunctionsM.cpp
@@ -2396,11 +2396,6 @@ void F_XboxOneSetServiceConfigurationID(RValue& Result, CInstance* selfinst, CIn
 	Result.kind = VALUE_REAL;
 	Result.val = -1;
 
-	if ((argc != 1) || (arg[0].kind != VALUE_STRING))
-	{
-		YYError("xboxone_set_service_configuration_id() - argument should be service_configuration_id", false);
-		return;
-	}
 #ifndef _GAMING_XBOX
 	g_PrimaryServiceConfigId = ConvertCharArrayToManagedString(YYGetString(arg, 0));	
 #endif


### PR DESCRIPTION
The YYGetXXX() functions already do type checking, remove duplicate
checks which reject things that can be converted to the expected type.