### PR TITLE
xboxone_get_token_and_signature() for series XS

### DIFF
--- a/DLL/GDKExtension/YoYo_FunctionsM.cpp
+++ b/DLL/GDKExtension/YoYo_FunctionsM.cpp
@@ -155,6 +155,7 @@ void InitYoYoFunctionsM( void )
 	Function_Add( "xboxone_set_savedata_user", F_XboxOneSetSaveDataUser, 1, true);
 	Function_Add( "xboxone_get_savedata_user", F_XboxOneGetSaveDataUser, 0, true);
 	Function_Add( "xboxone_get_file_error", F_XboxOneGetFileError, 0, true);
+	Function_Add( "xboxone_get_token_and_signature", F_XboxGetTokenAndSignature, 5, true);
 
 	Function_Add( "xboxone_set_service_configuration_id", F_XboxOneSetServiceConfigurationID, 1, true);
 #endif


### PR DESCRIPTION
The function `xboxone_get_token_and_signature()` is not yet available for the series XS module. This should do it?

Please append `?w=1` to this PR's URL to ignore the whitespace changes. See https://stackoverflow.com/questions/37007300/how-to-ignore-whitespace-in-github-when-comparing