### PR TITLE
Adds support for the GDK function XblMultiplayerActivityUpdateRecentP…

### DIFF
--- a/DLL/GDKExtension/YoYo_FunctionsM.cpp
+++ b/DLL/GDKExtension/YoYo_FunctionsM.cpp
@@ -2709,3 +2709,36 @@ void F_XboxLiveNotAvailable(RValue& Result, CInstance* selfinst, CInstance* othe
 
 	DebugConsoleOutput("Function not available without Xbox Live\n");
 }
+
+YYEXPORT
+void F_XboxOneUpdateRecentPlayers(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)
+{
+	XblContextHandle xbl_ctx;
+	uint64 user_id = (uint64)YYGetInt64(arg, 0);
+	uint64 user_id_recent = (uint64)YYGetInt64(arg, 1);
+
+	{
+		XUM_LOCK_MUTEX;
+		XUMuser* user = XUM::GetUserFromId(user_id);
+
+		if (user == NULL)
+		{
+			DebugConsoleOutput("xboxone_update_recent_players - couldn't find user_id\n");
+
+			Result.val = -1;
+			return;
+		}
+
+		HRESULT hr = XblContextCreateHandle(user->user, &xbl_ctx);
+		if (!SUCCEEDED(hr))
+		{
+			DebugConsoleOutput("xboxone_update_recent_players - couldn't create xbl handle (HRESULT 0x%08X)\n", (unsigned)(hr));
+
+			Result.val = -2;
+			return;
+		}
+	}
+
+	XblMultiplayerActivityRecentPlayerUpdate update{ user_id_recent };
+	HRESULT results = XblMultiplayerActivityUpdateRecentPlayers(xbl_ctx, &update, 1);
+}

--- a/GDK_Project_GMS2/extensions/GDKExtension/GDKExtension.yy
+++ b/GDK_Project_GMS2/extensions/GDKExtension/GDKExtension.yy
@@ -45,6 +45,7 @@
         {"externalName":"F_XboxOneGetStatSocialLeaderboard","kind":1,"help":"xboxone_stats_get_social_leaderboard(user_id, stat, num_entries, start_rank, start_at_user, ascending, favourites_only)","hidden":false,"returnType":1,"argCount":0,"args":[],"resourceVersion":"1.0","name":"xboxone_stats_get_social_leaderboard","tags":[],"resourceType":"GMExtensionFunction",},
         {"externalName":"F_XboxOneSetAchievementProgress","kind":1,"help":"xboxone_achievements_set_progress(user_id, achievement, progress)","hidden":false,"returnType":1,"argCount":0,"args":[],"resourceVersion":"1.0","name":"xboxone_achievements_set_progress","tags":[],"resourceType":"GMExtensionFunction",},
         {"externalName":"F_XboxReadPlayerLeaderboard","kind":1,"help":"xboxone_read_player_leaderboard(ident, player, numitems, friendfilter)","hidden":false,"returnType":1,"argCount":0,"args":[],"resourceVersion":"1.0","name":"xboxone_read_player_leaderboard","tags":[],"resourceType":"GMExtensionFunction",},
+        {"externalName":"F_XboxOneUpdateRecentPlayers","kind":1,"help":"xboxone_update_recent_players(user_id, user_id_recent)","hidden":false,"returnType":1,"argCount":0,"args":[],"resourceVersion":"1.0","name":"xboxone_update_recent_players","tags":[],"resourceType":"GMExtensionFunction",},
         {"externalName":"F_XboxOneSetRichPresence","kind":1,"help":"xboxone_set_rich_presence(user_id, is_user_active, rich_presence_string)","hidden":false,"returnType":1,"argCount":0,"args":[],"resourceVersion":"1.0","name":"xboxone_set_rich_presence","tags":[],"resourceType":"GMExtensionFunction",},
         {"externalName":"F_XboxCheckPrivilege","kind":1,"help":"xboxone_check_privilege(user_id, privilege_id, attempt_resolution)","hidden":false,"returnType":1,"argCount":0,"args":[],"resourceVersion":"1.0","name":"xboxone_check_privilege","tags":[],"resourceType":"GMExtensionFunction",},
         {"externalName":"gdk_save_group_begin","kind":1,"help":"gdk_save_group_begin(container_name)","hidden":false,"returnType":1,"argCount":0,"args":[
@@ -128,6 +129,7 @@
         {"name":"xboxone_achievements_set_progress","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"xboxone_get_achievement","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"xboxone_read_player_leaderboard","path":"extensions/GDKExtension/GDKExtension.yy",},
+        {"name":"xboxone_update_recent_players","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"xboxone_set_rich_presence","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"xboxone_check_privilege","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"gdk_save_group_begin","path":"extensions/GDKExtension/GDKExtension.yy",},


### PR DESCRIPTION
Adds support for the GDK function XblMultiplayerActivityUpdateRecentPlayers, exposed through xboxone_update_recent_players.
The function xboxone_update_recent_players, takes a user id for the current active player and a user id for a player that the current user is playing with.
    
This function updates the xbox user's recent players list.
I am currently using this function in a game that is going through certification right now as it is a requirement to update the recent Xbox players list.

**See Issue:** #66 

**See GDK PC requirement:** [67 Maintaining Multiplayer Session State](https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/policies/xr/xr067) 
