### PR TITLE
Adding support for generating localised shell resources

### DIFF
--- a/source/GDKExtension_gml/extensions/GDKExtension/post_package_step.bat
+++ b/source/GDKExtension_gml/extensions/GDKExtension/post_package_step.bat
@@ -48,6 +48,14 @@ call %Utils% itemCopyTo "%GDK_PATH%\PlayFab.PartyXboxLive.Cpp\Redist\CommonConfi
 call %Utils% itemCopyTo "%GDK_PATH%\Xbox.XCurl.API\Redist\CommonConfiguration\neutral\XCurl.dll" "XCurl.dll"
 popd
 
+:: Generate localisation data (if appropriate)
+if exist "%YYoutputFolder%\GDKExtensionStrings" (
+	makepkg localize /d "%YYoutputFolder%" /resw GDKExtensionStrings
+	if ERRORLEVEL 1 (
+		call %Utils% logError "Unable to complete 'makepkg localize'."
+	)
+)
+
 :: Generate map
 makepkg genmap /f "%YYoutputFolder%\layout.xml" /d "%YYoutputFolder%"
 if ERRORLEVEL 1 (

--- a/source/GDKExtension_gml/extensions/GDKExtension/post_run_step.bat
+++ b/source/GDKExtension_gml/extensions/GDKExtension/post_run_step.bat
@@ -58,6 +58,14 @@ set outputPath=%cd%\%outputPath%
 
 popd
 
+:: Generate localisation data (if appropriate)
+if exist "%YYoutputFolder%\GDKExtensionStrings" (
+	makepkg localize /d "%YYoutputFolder%" /resw GDKExtensionStrings
+	if ERRORLEVEL 1 (
+		call %Utils% logError "Unable to complete 'makepkg localize'."
+	)
+)
+
 :: Register the application (capture output)
 set "tempOut=%YYtempFolderUnmapped%\wdapp.out"
 wdapp register "%YYoutputFolder%" > "%tempOut%"


### PR DESCRIPTION
In order to use this the user needs to make some modifications to both their `MicrosoftGame.Config` file and their project:

- In their `MicrosoftGame.Config` file, they need to:
  - Change the value of `DefaultDisplayName` in `ShellVisuals` to `"ms-resource:ApplicationDisplayName"`
  - Change the value of `Description` in `ShellVisuals` to `"ms-resource:ApplicationDescription"`
  - Add a section which declares which languages they want to support using standard language\region codes (this should be in the `Game` section), i.e.:

```
<Resources>
    <Resource Language="en-us" />
    <Resource Language="en-gb" />
    <Resource Language="de-de" />
</Resources>
```

- In their project they need to add some folders to included files:
  - In the root of included files they should add a `GDKExtensionStrings` folder
  - Inside the `GDKExtensionStrings` folder they should add one for each supported language, i.e. `en-us` for American English and `de-de` for German, so for the above list of languages the directory structure would be:

```
GDKExtensionStrings\en-us
GDKExtensionStrings\en-gb
GDKExtensionStrings\de-de
```

  - Inside the base `GDKExtensionStrings` folder they should add an XML file named `resources.resw` which will contains the fallback language info and should look like the following (where the values should be replaced with the required defaults):

```
<?xml version="1.0" encoding="utf-8"?>
<root>
    <data name="ApplicationDescription">
        <value>Default App Description Here</value>
    </data>
    <data name="ApplicationDisplayName">
        <value>Default Display Name Here</value>
    </data>
</root>
```

Inside each of the language-specific folders they should add another `resources.resw` file with the appropriate values for that language.